### PR TITLE
Updated enrichment table

### DIFF
--- a/Content/Using Illuminate/Illuminate Enrichments.htm
+++ b/Content/Using Illuminate/Illuminate Enrichments.htm
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <html xmlns:MadCap="http://www.madcapsoftware.com/Schemas/MadCap.xsd">
-    <head>
-        <link href="../Resources/TableStyles/Alternate-Row-Color.css" rel="stylesheet" MadCap:stylesheetType="table" /><title>Illuminate Enrichments</title>
-    </head>
-    <body>
+  <head>
+      <link href="../Resources/TableStyles/Alternate-Row-Color.css" rel="stylesheet" MadCap:stylesheetType="table" /><title>Illuminate Enrichments</title>
+  </head>
+  <body>
         <MadCap:snippetBlock src="../Resources/Snippets/IlluminateBanner.flsnp" />
         <p>Illuminate functionality includes enriching events with additional data that can help contextualize events. This is done throughout Illuminate, both in the core functionality and in many of the Illuminate processing packs. This article focuses on the enrichments added and used by Illuminate core.        </p>
         <p>Some of the lookups provided in Illuminate can be customized by the user, as detailed e<MadCap:annotation MadCap:createDate="2025-02-07T12:45:05.2348821-09:00" MadCap:creator="AnnieZempel" MadCap:initials="AN" MadCap:comment="revise" MadCap:editor="AnnieZempel" MadCap:editDate="2025-02-07T12:45:06.6522482-09:00">xplained in the descriptions of the lookups where it applies.</MadCap:annotation></p>
@@ -84,116 +84,178 @@
             <li><code class="linecode">host_ip</code>
             </li>
         </ul>
-        <p>When any of these fields exist, a lookup with the adapter titled <code class="linecode">core_ip_processing_reserved_ip_ranges_adapter</code> will be used to identify the use of any reserved IP address ranges. The reserved ranges used are:</p>
-        <table style="mc-table-style: url('../Resources/TableStyles/Alternate-Row-Color.css');" class="TableStyle-Alternate-Row-Color" cellspacing="21">
-            <thead>
-                <tr class="TableStyle-Alternate-Row-Color-Head-Header1">
-                    <th class="TableStyle-Alternate-Row-Color-HeadE-Column1-Header1">Range(s)</th>
-                    <th class="TableStyle-Alternate-Row-Color-HeadD-Column1-Header1">Tag Suffixes</th>
-                </tr>
-            </thead>
-            <tbody>
-                <tr class="TableStyle-Alternate-Row-Color-Body-Body1">
-                    <td class="TableStyle-Alternate-Row-Color-BodyE-Column1-Body1">
-                  192.168.0.0/16, 172.16.0.0/12, 10.0.0.0/8, <a href="https://www.rfc-editor.org/rfc/rfc1918">RFC1918</a></td>
-                    <td class="TableStyle-Alternate-Row-Color-BodyD-Column1-Body1"><![CDATA[
-                  ]]><code class="linecode">reserved_ip</code>, <code class="linecode">rfc1918</code>, <code class="linecode">is_internal
-</code><![CDATA[                ]]></td>
-                </tr>
-                <tr class="TableStyle-Alternate-Row-Color-Body-Body2">
-                    <td class="TableStyle-Alternate-Row-Color-BodyE-Column1-Body2">
-                  127.0.0.0/8, <a href="https://www.rfc-editor.org/rfc/rfc1122#page-31">RFC1122</a>: See section 3.2.1.3 regarding loopback addressing
-                </td>
-                    <td class="TableStyle-Alternate-Row-Color-BodyD-Column1-Body2"><code class="linecode">               reserved_ip</code>, <code class="linecode">is_internal</code>, <code class="linecode">is_loopback</code>, <code class="linecode">rfc1122</code><![CDATA[                ]]></td>
-                </tr>
-                <tr class="TableStyle-Alternate-Row-Color-Body-Body1">
-                    <td class="TableStyle-Alternate-Row-Color-BodyE-Column1-Body1">
-                  169.254.0.0/16, <a href="https://www.rfc-editor.org/rfc/rfc3927">RFC3927</a>: IPv4 link-local addressing (A.K.A. APIPA addressing)
-                </td>
-                    <td class="TableStyle-Alternate-Row-Color-BodyD-Column1-Body1"><![CDATA[
-                  ]]><code class="linecode">reserved_ip</code>, <code class="linecode">is_internal</code>, <code class="linecode">rfc3297</code><![CDATA[
-                ]]></td>
-                </tr>
-                <tr class="TableStyle-Alternate-Row-Color-Body-Body2">
-                    <td class="TableStyle-Alternate-Row-Color-BodyE-Column1-Body2">
-                  224.0.0.0/4, <a href="https://www.rfc-editor.org/rfc/rfc3171">RFC3171</a>: IPv4 Multicast addressing
-                </td>
-                    <td class="TableStyle-Alternate-Row-Color-BodyD-Column1-Body2"><![CDATA[
-                  ]]><code class="linecode">multicast</code>, <code class="linecode">reserved_ip</code>, <code class="linecode">rfc3171
-</code><![CDATA[                ]]></td>
-                </tr>
-                <tr class="TableStyle-Alternate-Row-Color-Body-Body1">
-                    <td class="TableStyle-Alternate-Row-Color-BodyE-Column1-Body1">
-                  fe80::/10, ff00::/8, ::1/128, ::/128, ::FFFF:0:0/96, <a href="https://www.rfc-editor.org/rfc/rfc4291.html#section-2.4">RFC4291</a>: See section 2.4, IPv6 Address Architecture
-                </td>
-                    <td class="TableStyle-Alternate-Row-Color-BodyD-Column1-Body1"><![CDATA[
-                  ]]><code class="linecode">reserved_ip</code>, <code class="linecode">is_internal</code>, <code class="linecode">rfc4291</code><![CDATA[
-                ]]></td>
-                </tr>
-                <tr class="TableStyle-Alternate-Row-Color-Body-Body2">
-                    <td class="TableStyle-Alternate-Row-Color-BodyE-Column1-Body2">
-                  fc00::/7, <a href="https://www.rfc-editor.org/rfc/rfc4193#section-3.1">RFC4193</a>: See section 3.1, IPv6 unique local unicast addressing
-                </td>
-                    <td class="TableStyle-Alternate-Row-Color-BodyD-Column1-Body2"><![CDATA[
-                  ]]><code class="linecode">reserved_ip</code>, <code class="linecode">is_internal</code>, <code class="linecode">rfc4193</code><![CDATA[                ]]></td>
-                </tr>
-                <tr class="TableStyle-Alternate-Row-Color-Body-Body1">
-                    <td class="TableStyle-Alternate-Row-Color-BodyE-Column1-Body1">
-                  2002::/16, <a href="https://www.rfc-editor.org/rfc/rfc3056#section-2">RFC3056</a>: IPv6 encapsulation of IPv4
-                </td>
-                    <td class="TableStyle-Alternate-Row-Color-BodyD-Column1-Body1"><code class="linecode">                reserved_ip</code>, <code class="linecode">6_to_4</code>, <code class="linecode">rfc3056</code><![CDATA[
-                ]]></td>
-                </tr>
-                <tr class="TableStyle-Alternate-Row-Color-Body-Body2">
-                    <td class="TableStyle-Alternate-Row-Color-BodyE-Column1-Body2">
-                  2001::/32, <a href="https://www.rfc-editor.org/rfc/rfc4380">RFC4380</a>: Teredo
-                </td>
-                    <td class="TableStyle-Alternate-Row-Color-BodyD-Column1-Body2"><code class="linecode">reserved_ip</code>, <code class="linecode">teredo</code>, <code class="linecode">rfc4380</code><![CDATA[
-                ]]></td>
-                </tr>
-                <tr class="TableStyle-Alternate-Row-Color-Body-Body1">
-                    <td class="TableStyle-Alternate-Row-Color-BodyE-Column1-Body1">
-                  192.0.2.0/24, 198.51.100.0/24, 203.0.113.0/24, <a href="https://www.rfc-editor.org/rfc/rfc5737">RFC5737</a>: IPv4 reserved address block for documentation
-                </td>
-                    <td class="TableStyle-Alternate-Row-Color-BodyD-Column1-Body1"><![CDATA[
-                  ]]><code class="linecode">reserved_ip</code>, <code class="linecode">is_illegal</code>, <code class="linecode">rfc5737</code><![CDATA[
-                ]]></td>
-                </tr>
-                <tr class="TableStyle-Alternate-Row-Color-Body-Body2">
-                    <td class="TableStyle-Alternate-Row-Color-BodyE-Column1-Body2">
-                  198.18.0.0/15, <a href="https://www.rfc-editor.org/rfc/rfc2544#appendix-C.2.2">RFC2544</a>: IPv4 reserved addresses for benchmark testing
-                </td>
-                    <td class="TableStyle-Alternate-Row-Color-BodyD-Column1-Body2"><![CDATA[
-                  ]]><code class="linecode">reserved_ip</code>, <code class="linecode">is_internal</code>, <code class="linecode">rfc2544</code><![CDATA[
-                ]]></td>
-                </tr>
-                <tr class="TableStyle-Alternate-Row-Color-Body-Body1">
-                    <td class="TableStyle-Alternate-Row-Color-BodyE-Column1-Body1">
-                  2001:db8::/32, <a href="https://www.rfc-editor.org/rfc/rfc3849">RFC3849</a>: IPv6 reserved address block for documentation
-                </td>
-                    <td class="TableStyle-Alternate-Row-Color-BodyD-Column1-Body1"><code class="linecode">                  reserved_ip</code>, <code class="linecode">is_illegal</code>, <code class="linecode">rfc3849</code><![CDATA[
-                ]]></td>
-                </tr>
-                <tr class="TableStyle-Alternate-Row-Color-Body-Body2">
-                    <td class="TableStyle-Alternate-Row-Color-BodyB-Column1-Body2">
-                  2001:10::/28, <a href="https://www.rfc-editor.org/rfc/rfc4843">RFC4843</a>: Orchid routing
-                </td>
-                    <td class="TableStyle-Alternate-Row-Color-BodyA-Column1-Body2"><code class="linecode">                  reserved_ip</code>, <code class="linecode">rfc4843</code><![CDATA[
-                ]]></td>
-                </tr>
-            </tbody>
-        </table>
-        <p>Illuminate will detect when an IP in one of the key fields is in scope for any of the identified ranges and add values to the <code class="linecode">gim_tags</code> field.
-        The values added have some common values and some that are specific to the ranges, and these will be prefixed with the context of the key field for which Illuminate has identified.
-        For example, if the value <code class="linecode">source_ip</code> value is the IP address <code class="linecode">192.0.2.10</code> , Illuminate will add the following values to the <code class="linecode">gim_tags</code> field:
-        </p>
-        <ul>
-            <li><code class="linecode">source_reserved_ip</code>
-            </li>
-            <li><code class="linecode">source_is_illegal</code>
-            </li>
-            <li><code class="linecode">source_rfc5737</code>
-            </li>
-        </ul>
-    </body>
+        <p>When any of these fields exist, a lookup with the adapter titled <code class="linecode">core_ip_processing_reserved_ip_ranges_adapter</code> will be used to identify the use of any reserved IP address ranges. The reserved ranges used are:</p><MadCap:dropDown>
+        <MadCap:dropDownHead>
+            <MadCap:dropDownHotspot>Network Range Enrichments</MadCap:dropDownHotspot>
+        </MadCap:dropDownHead>
+        <MadCap:dropDownBody>
+            <table style="width: 100%; mc-table-style: url('../Resources/TableStyles/Alternate-Row-Color.css');" class="TableStyle-Alternate-Row-Color" cellspacing="21">
+                <col class="TableStyle-Alternate-Row-Color-Column-Column1" style="width: 212px;" />
+                <col class="TableStyle-Alternate-Row-Color-Column-Column1" style="width: 246px;" />
+                <col class="TableStyle-Alternate-Row-Color-Column-Column1" />
+                <thead>
+                    <tr class="TableStyle-Alternate-Row-Color-Head-Header1">
+                        <th class="TableStyle-Alternate-Row-Color-HeadE-Column1-Header1">Network Range</th>
+                        <th class="TableStyle-Alternate-Row-Color-HeadE-Column1-Header1">Tag Suffix</th>
+                        <th class="TableStyle-Alternate-Row-Color-HeadD-Column1-Header1">Description</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr class="TableStyle-Alternate-Row-Color-Body-Body1">
+                        <td class="TableStyle-Alternate-Row-Color-BodyE-Column1-Body1">192.168.0.0/16</td>
+                        <td class="TableStyle-Alternate-Row-Color-BodyE-Column1-Body1"><code class="linecode">reserved_ip</code>, <code class="linecode">rfc1918</code>, <code class="linecode">is_internal</code></td>
+                        <td class="TableStyle-Alternate-Row-Color-BodyD-Column1-Body1"><a href="https://www.rfc-editor.org/rfc/rfc1918">RFC1918</a></td>
+                    </tr>
+                    <tr class="TableStyle-Alternate-Row-Color-Body-Body2">
+                        <td class="TableStyle-Alternate-Row-Color-BodyE-Column1-Body2">10.0.0.0/8</td>
+                        <td class="TableStyle-Alternate-Row-Color-BodyE-Column1-Body2"><code class="linecode">reserved_ip</code>, <code class="linecode">rfc1918</code>, <code class="linecode">is_internal</code></td>
+                        <td class="TableStyle-Alternate-Row-Color-BodyD-Column1-Body2"><a href="https://www.rfc-editor.org/rfc/rfc1918">RFC1918</a></td>
+                    </tr>
+                    <tr class="TableStyle-Alternate-Row-Color-Body-Body1">
+                        <td class="TableStyle-Alternate-Row-Color-BodyE-Column1-Body1">172.16.0.0/12</td>
+                        <td class="TableStyle-Alternate-Row-Color-BodyE-Column1-Body1"><code class="linecode">reserved_ip</code>, <code class="linecode">rfc1918</code>, <code class="linecode">is_internal</code></td>
+                        <td class="TableStyle-Alternate-Row-Color-BodyD-Column1-Body1"><a href="https://www.rfc-editor.org/rfc/rfc1918">RFC1918</a></td>
+                    </tr>
+                    <tr class="TableStyle-Alternate-Row-Color-Body-Body2">
+                        <td class="TableStyle-Alternate-Row-Color-BodyE-Column1-Body2">127.0.0.0/8</td>
+                        <td class="TableStyle-Alternate-Row-Color-BodyE-Column1-Body2"><code class="linecode">reserved_ip</code>, <code class="linecode">is_internal</code>, <code class="linecode">is_loopback</code>, <code class="linecode">rfc1122</code></td>
+                        <td class="TableStyle-Alternate-Row-Color-BodyD-Column1-Body2"><a href="https://www.rfc-editor.org/rfc/rfc1122#page-31">RFC1122</a>: See section 3.2.1.3 regarding loopback addressing</td>
+                    </tr>
+                    <tr class="TableStyle-Alternate-Row-Color-Body-Body1">
+                        <td class="TableStyle-Alternate-Row-Color-BodyE-Column1-Body1">169.254.0.0/16</td>
+                        <td class="TableStyle-Alternate-Row-Color-BodyE-Column1-Body1"><code class="linecode">reserved_ip</code>, <code class="linecode">is_internal</code>, <code class="linecode">rfc3927</code></td>
+                        <td class="TableStyle-Alternate-Row-Color-BodyD-Column1-Body1"><a href="https://www.rfc-editor.org/rfc/rfc3927">RFC3927</a>: IPv4 link-local addressing (A.K.A. APIPA addressing)</td>
+                    </tr>
+                    <tr class="TableStyle-Alternate-Row-Color-Body-Body2">
+                        <td class="TableStyle-Alternate-Row-Color-BodyE-Column1-Body2">224.0.0.0/4</td>
+                        <td class="TableStyle-Alternate-Row-Color-BodyE-Column1-Body2"><code class="linecode">multicast</code>, <code class="linecode">reserved_ip</code>, <code class="linecode">rfc5771</code></td>
+                        <td class="TableStyle-Alternate-Row-Color-BodyD-Column1-Body2"><a href="https://www.rfc-editor.org/rfc/rfc5771">RFC5771</a>: IPv4 Multicast addressing</td>
+                    </tr>
+                    <tr class="TableStyle-Alternate-Row-Color-Body-Body1">
+                        <td class="TableStyle-Alternate-Row-Color-BodyE-Column1-Body1">fe80::/10</td>
+                        <td class="TableStyle-Alternate-Row-Color-BodyE-Column1-Body1"><code class="linecode">reserved_ip</code>, <code class="linecode">is_internal</code>, <code class="linecode">rfc4291</code></td>
+                        <td class="TableStyle-Alternate-Row-Color-BodyD-Column1-Body1"><a href="https://www.rfc-editor.org/rfc/rfc4291.html#section-2.4">RFC4291</a>: See section 2.4, IPv6 Address Architecture</td>
+                    </tr>
+                    <tr class="TableStyle-Alternate-Row-Color-Body-Body2">
+                        <td class="TableStyle-Alternate-Row-Color-BodyE-Column1-Body2">fc00::/7</td>
+                        <td class="TableStyle-Alternate-Row-Color-BodyE-Column1-Body2"><code class="linecode">reserved_ip</code>, <code class="linecode">is_internal</code>, <code class="linecode">rfc4193</code></td>
+                        <td class="TableStyle-Alternate-Row-Color-BodyD-Column1-Body2"><a href="https://www.rfc-editor.org/rfc/rfc4193#section-3.1">RFC4193</a>: See section 3.1, IPv6 unique local unicast addressing</td>
+                    </tr>
+                    <tr class="TableStyle-Alternate-Row-Color-Body-Body1">
+                        <td class="TableStyle-Alternate-Row-Color-BodyE-Column1-Body1">ff00::/8</td>
+                        <td class="TableStyle-Alternate-Row-Color-BodyE-Column1-Body1"><code class="linecode">multicast</code>, <code class="linecode">reserved_ip</code>, <code class="linecode">rfc4291</code></td>
+                        <td class="TableStyle-Alternate-Row-Color-BodyD-Column1-Body1"><a href="https://www.rfc-editor.org/rfc/rfc4291.html#section-2.4">RFC4291</a>: See section 2.4, IPv6 Address Architecture</td>
+                    </tr>
+                    <tr class="TableStyle-Alternate-Row-Color-Body-Body2">
+                        <td class="TableStyle-Alternate-Row-Color-BodyE-Column1-Body2">::1/128</td>
+                        <td class="TableStyle-Alternate-Row-Color-BodyE-Column1-Body2"><code class="linecode">reserved_ip</code>, <code class="linecode">is_internal</code>, <code class="linecode">is_loopback</code>, <code class="linecode">rfc4291</code></td>
+                        <td class="TableStyle-Alternate-Row-Color-BodyD-Column1-Body2"><a href="https://www.rfc-editor.org/rfc/rfc4291.html#section-2.4">RFC4291</a>: See section 2.4, IPv6 Address Architecture</td>
+                    </tr>
+                    <tr class="TableStyle-Alternate-Row-Color-Body-Body1">
+                        <td class="TableStyle-Alternate-Row-Color-BodyE-Column1-Body1">2002::/16</td>
+                        <td class="TableStyle-Alternate-Row-Color-BodyE-Column1-Body1"><code class="linecode">reserved_ip</code>, <code class="linecode">6_to_4</code>, <code class="linecode">rfc3056</code></td>
+                        <td class="TableStyle-Alternate-Row-Color-BodyD-Column1-Body1"><a href="https://www.rfc-editor.org/rfc/rfc3056#section-2">RFC3056</a>: IPv6 encapsulation of IPv4</td>
+                    </tr>
+                    <tr class="TableStyle-Alternate-Row-Color-Body-Body2">
+                        <td class="TableStyle-Alternate-Row-Color-BodyE-Column1-Body2">2001::/32</td>
+                        <td class="TableStyle-Alternate-Row-Color-BodyE-Column1-Body2"><code class="linecode">reserved_ip</code>, <code class="linecode">teredo</code>, <code class="linecode">rfc4380</code></td>
+                        <td class="TableStyle-Alternate-Row-Color-BodyD-Column1-Body2"><a href="https://www.rfc-editor.org/rfc/rfc4380">RFC4380</a>: Teredo</td>
+                    </tr>
+                    <tr class="TableStyle-Alternate-Row-Color-Body-Body1">
+                        <td class="TableStyle-Alternate-Row-Color-BodyE-Column1-Body1">192.0.2.0/24</td>
+                        <td class="TableStyle-Alternate-Row-Color-BodyE-Column1-Body1"><code class="linecode">reserved_ip</code>, <code class="linecode">is_illegal</code>, <code class="linecode">rfc5737</code></td>
+                        <td class="TableStyle-Alternate-Row-Color-BodyD-Column1-Body1"><a href="https://www.rfc-editor.org/rfc/rfc5737">RFC5737</a>: IPv4 reserved address block for documentation</td>
+                    </tr>
+                    <tr class="TableStyle-Alternate-Row-Color-Body-Body2">
+                        <td class="TableStyle-Alternate-Row-Color-BodyE-Column1-Body2">198.18.0.0/15</td>
+                        <td class="TableStyle-Alternate-Row-Color-BodyE-Column1-Body2"><code class="linecode">reserved_ip</code>, <code class="linecode">is_internal</code>, <code class="linecode">rfc2544</code></td>
+                        <td class="TableStyle-Alternate-Row-Color-BodyD-Column1-Body2"><a href="https://www.rfc-editor.org/rfc/rfc2544#appendix-C.2.2">RFC2544</a>: IPv4 reserved addresses for benchmark testing</td>
+                    </tr>
+                    <tr class="TableStyle-Alternate-Row-Color-Body-Body1">
+                        <td class="TableStyle-Alternate-Row-Color-BodyE-Column1-Body1">198.51.100.0/24</td>
+                        <td class="TableStyle-Alternate-Row-Color-BodyE-Column1-Body1"><code class="linecode">reserved_ip</code>, <code class="linecode">is_internal</code>, <code class="linecode">rfc5737</code></td>
+                        <td class="TableStyle-Alternate-Row-Color-BodyD-Column1-Body1"><a href="https://www.rfc-editor.org/rfc/rfc5737">RFC5737</a>: IPv4 reserved address block for documentation</td>
+                    </tr>
+                    <tr class="TableStyle-Alternate-Row-Color-Body-Body2">
+                        <td class="TableStyle-Alternate-Row-Color-BodyE-Column1-Body2">203.0.113.0/24</td>
+                        <td class="TableStyle-Alternate-Row-Color-BodyE-Column1-Body2"><code class="linecode">reserved_ip</code>, <code class="linecode">is_internal</code>, <code class="linecode">rfc5737</code></td>
+                        <td class="TableStyle-Alternate-Row-Color-BodyD-Column1-Body2"><a href="https://www.rfc-editor.org/rfc/rfc5737">RFC5737</a>: IPv4 reserved address block for documentation</td>
+                    </tr>
+                    <tr class="TableStyle-Alternate-Row-Color-Body-Body1">
+                        <td class="TableStyle-Alternate-Row-Color-BodyE-Column1-Body1">2001:db8::/32</td>
+                        <td class="TableStyle-Alternate-Row-Color-BodyE-Column1-Body1"><code class="linecode">reserved_ip</code>, <code class="linecode">is_illegal</code>, <code class="linecode">rfc3849</code></td>
+                        <td class="TableStyle-Alternate-Row-Color-BodyD-Column1-Body1"><a href="https://www.rfc-editor.org/rfc/rfc3849">RFC3849</a>: IPv6 reserved address block for documentation</td>
+                    </tr>
+                    <tr class="TableStyle-Alternate-Row-Color-Body-Body2">
+                        <td class="TableStyle-Alternate-Row-Color-BodyE-Column1-Body2">5f00::/8</td>
+                        <td class="TableStyle-Alternate-Row-Color-BodyE-Column1-Body2"><code class="linecode">reserved_ip</code>, <code class="linecode">rfc9602</code>></td>
+                        <td class="TableStyle-Alternate-Row-Color-BodyD-Column1-Body2"><a href="https://www.rfc-editor.org/rfc/rfc9602">RFC9602</a>: IPv6 segment routing</td>
+                    </tr>
+                    <tr class="TableStyle-Alternate-Row-Color-Body-Body1">
+                        <td class="TableStyle-Alternate-Row-Color-BodyE-Column1-Body1">2001:20::/28</td>
+                        <td class="TableStyle-Alternate-Row-Color-Body-Column-Column1-Body1"><code class="linecode">reserved_ip</code>, <code class="linecode">rfc7343</code></td>
+                        <td class="TableStyle-Alternate-Row-Color-BodyD-Column1-Body1"><a href="https://www.rfc-editor.org/rfc/rfc7343">RFC7343</a>: ORCHIDV2 routing</td>
+                    </tr>
+                    <tr class="TableStyle-Alternate-Row-Color-Body-Body2">
+                        <td class="TableStyle-Alternate-Row-Color-BodyE-Column1-Body2">::/128</td>
+                        <td class="TableStyle-Alternate-Row-Color-BodyE-Column1-Body2"><code class="linecode">reserved_ip</code>, <code class="linecode">is_internal</code>, <code class="linecode">rfc4291</code></td>
+                        <td class="TableStyle-Alternate-Row-Color-BodyD-Column1-Body2"><a href="https://www.rfc-editor.org/rfc/rfc4291.html#section-2.4">RFC4291</a>: See section 2.4, IPv6 Address Architecture</td>
+                    </tr>
+                    <tr class="TableStyle-Alternate-Row-Color-Body-Body1">
+                        <td class="TableStyle-Alternate-Row-Color-BodyE-Column1-Body1">::FFFF:0:0/96</td>
+                        <td class="TableStyle-Alternative-Row-Color-BodyE-Column1-Body1"><code class="linecode">reserved_ip</code>, <code class="linecode">ipv4_mapped</code>, <code class="linecode">rfc4291</code></td>
+                        <td class="TableStyle-Alternate-Row-Color-BodyD-Column1-Body1"><a href="https://www.rfc-editor.org/rfc/rfc4291.html#section-2.4">RFC4291</a>: See section 2.4, IPv6 Address Architecture</td>
+                    </tr>
+                    <tr class="TableStyle-Alternate-Row-Color-Body-Body2">
+                        <td class="TableStyle-Alternate-Row-Color-BodyE-Column1-Body2">100.64.0.0/10</td>
+                        <td class="TableStyle-Alternate-Row-Color-BodyE-Column1-Body2"><code class="linecode">reserved_ip</code>, <code class="linecode">is_internal</code>, <code class="linecode">rfc6598</code></td>
+                        <td class="TableStyle-Alternate-Row-Color-BodyD-Column1-Body2"><a href="https://www.rfc-editor.org/rfc/rfc6598">RFC6598</a>: Carrier-Grade NAT (CGN)</td>
+                    </tr>
+                    <tr class="TableStyle-Alternate-Row-Color-Body-Body1">
+                        <td class="TableStyle-Alternate-Row-Color-BodyE-Column1-Body1">2001:2::/48</td>
+                        <td class="TableStyle-Alternate-Row-Color-BodyE-Column1-Body1"><code class="linecode">reserved_ip</code>, <code class="linecode">is_internal</code>, <code class="linecode">rfc5180</code></td>
+                        <td class="TableStyle-Alternate-Row-Color-BodyD-Column1-Body1"><a href="https://www.rfc-editor.org/rfc/rfc5180">RFC5180</a>: IPv6 reserved address block for benchmarking</td>
+                    </tr>
+                    <tr class="TableStyle-Alternate-Row-Color-Body-Body2">
+                        <td class="TableStyle-Alternate-Row-Color-BodyE-Column1-Body2">192.0.0.0/24</td>
+                        <td class="TableStyle-Alternate-Row-Color-Body-Column-Column1-Body2"><code class="linecode">reserved_ip</code>, <code class="linecode">is_internal</code>, <code class="linecode">rfc6890</code></td>
+                        <td class="TableStyle-Alternate-Row-Color-BodyD-Column1-Body2"><a href="https://www.rfc-editor.org/rfc/rfc6890.html">RFC6890</a>: IPv4 Special Purpose Address</td>
+                    </tr>
+                    <tr class="TableStyle-Alternate-Row-Color-Body-Body1">
+                        <td class="TableStyle-Alternate-Row-Color-BodyE-Column1-Body1">240.0.0.0/4</td>
+                        <td class="TableStyle-Alternate-Row-Color-BodyE-Column1-Body1"><code class="linecode">reserved_ip</code>, <code class="linecode">rfc1112</code></td>
+                        <td class="TableStyle-Alternate-Row-Color-BodyD-Column1-Body1">Reserved for future use, see <a href="https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml">this IETF page</td>
+                    </tr>
+                    <tr class="TableStyle-Alternate-Row-Color-Body-Body2">
+                        <td class="TableStyle-Alternate-Row-Color-BodyE-Column1-Body2">64:ff9b::/96</td>
+                        <td class="TableStyle-Alternate-Row-Color-BodyE-Column1-Body2"><code class="linecode">reserved_ip</code>, <code class="linecode">is_internal</code>, <code class="linecode">rfc6052</code></td>
+                        <td class="TableStyle-Alternate-Row-Color-BodyD-Column1-Body2"><a href="https://www.rfc-editor.org/rfc/rfc6052.html">RFC6052</a>: NAT64</td>
+                    </tr>
+                    <tr class="TableStyle-Alternate-Row-Color-Body-Body1">
+                        <td class="TableStyle-Alternate-Row-Color-BodyE-Column1-Body1">64:ff9b:1::/48</td>
+                        <td class="TableStyle-Alternate-Row-Color-BodyE-Column1-Body1"><code class="linecode">reserved_ip</code>, <code class="linecode">is_internal</code>, <code class="linecode">rfc8215</code></code></td>
+                        <td class="TableStyle-Alternate-Row-Color-BodyD-Column1-Body1"><a href="https://www.rfc-editor.org/rfc/rfc8215.html">RFC8215</a>: Local-use NAT64 </td>
+                    </tr>
+                </tbody>
+            </table>
+        </MadCap:dropDownBody>
+    </MadCap:dropDown>
+    <p>Illuminate will detect when an IP in one of the key fields is in scope for any of the identified ranges and add values to the <code class="linecode">gim_tags</code> field.
+    The values added have some common values and some that are specific to the ranges, and these will be prefixed with the context of the key field for which Illuminate has identified.
+    For example, if the value <code class="linecode">source_ip</code> value is the IP address <code class="linecode">192.0.2.10</code> , Illuminate will add the following values to the <code class="linecode">gim_tags</code> field:
+    </p>
+    <ul>
+        <li><code class="linecode">source_reserved_ip</code>
+        </li>
+        <li><code class="linecode">source_is_illegal</code>
+        </li>
+        <li><code class="linecode">source_rfc5737</code>
+        </li>
+    </ul>
+    <p>
+      <section class="warningBox">
+          <div class="title" style="font-weight: normal;"><b>Warning</b>:  In Illuminate 7.0.0 the enrichments will be assigned to the category fields, e.g. <code class="linecode">source_category</code>, <code class="linecode">host_category</code> and <code class="linecode">destination_category</code> instead of being assigned to <code class="linecode">gim_tags</code>.</div>
+      </section>
+    </p>
+  </body>
 </html>


### PR DESCRIPTION
## Notes for Reviewers

This PR updates the network range enrichment table, adding a third column and mirroring the recent update to the reserved IP range enrichment.

- [ ] The commit history must be preserved - please use the rebase-merge or standard merge option instead of squash-merge
- [ ] Sync up with the author before merging

